### PR TITLE
require 'benchmark_suite' needs to require 'suite' and 'ips' files

### DIFF
--- a/lib/benchmark_suite.rb
+++ b/lib/benchmark_suite.rb
@@ -1,3 +1,6 @@
+require 'benchmark/suite'
+require 'benchmark/ips'
+
 class BenchmarkSuite
   VERSION = '0.8.0'
 end


### PR DESCRIPTION
Evan, while working on the code for the codespeed benchmarking server I ran into a problem with loading reports that were marshaled to disk by benchmark_suite. Requiring the gem was insufficient to resolve the error because the gem wasn't requiring the 'suite' and 'ips' files.

This patch just fixes that up. Now any program that loads this gem can successfully Marshal.load a report file without error.
