### PR TITLE
Add helpers.rb

### DIFF
--- a/lib/benchmark/helpers.rb
+++ b/lib/benchmark/helpers.rb
@@ -1,0 +1,46 @@
+module Benchmark
+  module Helpers
+
+    def fixnum_max
+      if Object.const_defined?(:RUBY_ENGINE)
+        case RUBY_ENGINE
+        when "ruby"
+          2 ** (wordsize - 2) - 1
+        when "rbx"
+          Fixnum::MAX
+        when "jruby"
+          9223372036854775807
+        else
+          raise "Maximum Fixnum size now known yet for #{RUBY_ENGINE}"
+        end
+      else
+        2 ** (wordsize - 2) - 1
+      end
+    end
+    module_function :fixnum_max
+
+    def fixnum_min
+       if Object.const_defined?(:RUBY_ENGINE)
+        case RUBY_ENGINE
+        when "ruby"
+          - 2 ** (wordsize - 2)
+        when "rbx"
+          Fixnum::MIN
+        when "jruby"
+          -9223372036854775808
+        else
+          raise "Maximum Fixnum size now known yet for #{RUBY_ENGINE}"
+        end
+      else
+        - 2 ** (wordsize - 2)
+      end
+   end
+    module_function :fixnum_min
+
+    def wordsize
+      8 * 1.size
+    end
+    module_function :wordsize
+
+  end
+end

--- a/lib/benchmark_suite.rb
+++ b/lib/benchmark_suite.rb
@@ -1,5 +1,6 @@
 require 'benchmark/suite'
 require 'benchmark/ips'
+require 'benchmark/helpers'
 
 class BenchmarkSuite
   VERSION = '0.8.0'


### PR DESCRIPTION
Several fixnum benchmarks rely upon some helper methods defined in lib/benchmark/helpers.rb. When this got spun off to its own gem, that file was missed.
