### PR TITLE
Add missing block parameter in example

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,7 +20,7 @@ A set of enhancements to the standard library benchmark.rb
 
 require 'benchmark/ips'
 
-Benchmark.ips do
+Benchmark.ips do |x|
   # Typical mode, runs the block as many times as it can
   x.report("addition") { 1 + 2 }
 


### PR DESCRIPTION
This block parameter appears to be necessary but is missing from the example
