### PR TITLE
Add a half-length pre-warmup, to avoid penalizing later tests.

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -156,6 +156,24 @@ module Benchmark
 
     reports = []
 
+    # half-length pre-warmup to even out perf
+    half_warmup = warmup / 2.0
+    job.list.each do |item|
+      Timing.clean_env
+      
+      before.update!
+      start.update!
+      cur.update!
+
+      warmup_iter = 0
+
+      until start.elapsed?(cur, half_warmup)
+        item.call_times(1)
+        warmup_iter += 1
+        cur.update!
+      end
+    end
+
     job.list.each do |item|
       suite.warming item.label, warmup if suite
 


### PR DESCRIPTION
IPS currently warms up each test immediately before running it. This can potentially skew later results that cause invalidations or deoptimizations along code paths optimized earlier. For example, a later test may cause a site that was previously monomorphic to go polymorphic, causing that test to have degraded perf compared to earlier tests, even though a steady-state system would penalize all equally.

My change inserts a pre-benchmark half-length warmup run of all the benchmarks together without gathering any metrics. This brings us closer to steady-state numbers for the later warmup+benchmark loop.

The logic for the pre-warmup is mostly identical to the in-bench warmup to keep the system impact as similar as possible.
