### PR TITLE
Missing incrementation in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,6 +32,7 @@ Benchmark.ips do |x|
     i = 0
     while i < times
       1 + 2
+      i += 1
     end
   end
 


### PR DESCRIPTION
Hello,

The while loop body in the README does not increment `i`, making it an infinite loop.

See evanphx/benchmark-ips#4
