### PR TITLE
correct the SimpleReport initializer to match client call from Benchmark::Suite

### DIFF
--- a/lib/benchmark/suite.rb
+++ b/lib/benchmark/suite.rb
@@ -26,9 +26,9 @@ module Benchmark
     end
 
     class SimpleReport
-      def initialize
-        @start = nil
-        @end = nil
+      def initialize(s = nil, e = nil)
+        @start = s
+        @end = s
       end
 
       attr_reader :start, :end


### PR DESCRIPTION
The calling client requires the constructor takes two args

``` ruby
      if @report
        @reports[file] = @report
        @report = nil
      else
        @reports[file] = SimpleReport.new(start, fin)
      end
```

https://github.com/yangchenyun/benchmark_suite/blob/master/lib/benchmark/suite.rb#L101
